### PR TITLE
Replace auth pages and add role selection

### DIFF
--- a/frontend/templates/Login.html
+++ b/frontend/templates/Login.html
@@ -1,12 +1,16 @@
 {% load static %}
 <!DOCTYPE html>
-<html lang="en" class="scroll-smooth">
+<html lang="ru" class="scroll-smooth">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>EduPath Login</title>
+  <meta name="apple-mobile-web-app-capable" content="yes" />
+  <meta name="theme-color" content="#F9F9FB" />
+  <title>EduPath — Вход</title>
+
   <script src="https://cdn.tailwindcss.com"></script>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap" rel="stylesheet" />
+
   <style>
     :root {
       --brand-primary: #6C4DFF;
@@ -16,61 +20,107 @@
       --text-secondary: rgba(60, 60, 67, 0.6);
       --border-color: #D1D1D6;
     }
+
     body {
-      font-family: 'Inter', sans-serif;
+      font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
       background-color: var(--bg-main);
       color: var(--text-main);
     }
+
+    .text-secondary {
+      color: var(--text-secondary);
+    }
+
     input:focus {
-      outline: none;
       border-color: var(--brand-primary);
-      box-shadow: 0 0 0 2px rgba(108, 77, 255, 0.2);
+      box-shadow: 0 0 0 2px var(--brand-primary);
+      outline: none;
+    }
+
+    button, input[type="checkbox"] {
+      transition: all 0.2s ease-in-out;
+    }
+
+    input, button {
+      appearance: none;
+      -webkit-appearance: none;
     }
   </style>
 </head>
-<body class="flex flex-col min-h-screen">
 
-  <main class="flex-1 flex items-center justify-center px-4">
-    <div class="w-full max-w-md bg-white rounded-2xl shadow-xl p-8 space-y-6 border border-[var(--border-color)]">
-      <h2 class="text-2xl font-bold text-center">Войти в аккаунт</h2>
+<body class="flex items-center justify-center min-h-screen px-4 sm:px-6 lg:px-8 relative">
+  <!-- Логотип -->
+  <header class="absolute top-4 left-4 sm:top-6 sm:left-6">
+    <img src="{% static 'Icons/Logo.png' %}" alt="EduPath" class="h-9 sm:h-10 md:h-12" />
+  </header>
 
-      {% if error %}
-        <div class="text-red-600 text-sm text-center">{{ error }}</div>
-      {% endif %}
-
-      <form method="POST" action="/login/" class="space-y-4">
-        {% csrf_token %}
-        <div>
-          <label for="username" class="block text-sm font-medium">Логин</label>
-          <input id="username" name="username" type="text" required
-                 class="w-full px-4 py-2 border rounded-lg border-[var(--border-color)] bg-white" />
-        </div>
-
-        <div>
-          <label for="password" class="block text-sm font-medium">Пароль</label>
-          <input id="password" name="password" type="password" required
-                 class="w-full px-4 py-2 border rounded-lg border-[var(--border-color)] bg-white" />
-        </div>
-
-        <button type="submit"
-                class="w-full bg-[var(--brand-primary)] text-white py-2 rounded-lg font-semibold hover:bg-indigo-700 transition">
-          Войти
-        </button>
-      </form>
-
-      <p class="text-center text-sm text-[var(--text-secondary)]">
-        Нет аккаунта?
-        <a href="{% url 'register' %}" class="text-[var(--brand-primary)] hover:underline">Зарегистрироваться</a>
-      </p>
+  <!-- Основной блок -->
+  <main class="w-full max-w-md bg-white rounded-2xl shadow-xl overflow-hidden p-6 sm:p-8 md:p-10 border border-[var(--border-color)]">
+    <div class="mb-8 text-center">
+      <h1 class="text-2xl sm:text-3xl font-semibold mb-1 tracking-tight">С возвращением!</h1>
+      <h2 class="text-base sm:text-lg font-medium mb-2 tracking-tight">Войдите в аккаунт</h2>
+      <p class="text-xs sm:text-sm text-secondary">Рады видеть вас снова на EduPath</p>
     </div>
+
+    {% if error %}
+      <div class="text-red-600 text-center text-sm mb-2">{{ error }}</div>
+    {% endif %}
+
+    <!-- Форма -->
+    <form method="post" action="{% url 'login' %}" class="space-y-5 sm:space-y-6">
+      {% csrf_token %}
+      <!-- Имя пользователя -->
+      <div>
+        <label for="username" class="block mb-1 text-sm font-medium">Имя пользователя</label>
+        <input id="username" name="username" type="text" placeholder="Введите имя" required class="w-full px-4 py-3 text-sm rounded-lg border border-[var(--border-color)] bg-white transition" />
+      </div>
+
+      <!-- Пароль -->
+      <div>
+        <label for="password" class="block mb-1 text-sm font-medium">Пароль</label>
+        <div class="relative">
+          <input id="password" name="password" type="password" placeholder="Введите пароль" required class="w-full px-4 py-3 text-sm rounded-lg border border-[var(--border-color)] bg-white pr-12 transition" />
+          <button type="button" onclick="togglePassword('password', 'eyeIcon')" class="absolute top-1/2 right-3 -translate-y-1/2 cursor-pointer" aria-label="Показать пароль">
+            <svg id="eyeIcon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" class="w-5 h-5 text-gray-500 hover:text-black transition">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5s8.268 2.943 9.542 7c-1.274 4.057-5.065 7-9.542 7s-8.268-2.943-9.542-7z" />
+            </svg>
+          </button>
+        </div>
+      </div>
+
+      <!-- Чекбокс и "Забыли пароль" -->
+      <div class="flex items-center justify-between text-sm mt-2">
+        <label class="flex items-center gap-2 cursor-pointer select-none">
+          <input type="checkbox" id="rememberMe" class="accent-[var(--brand-primary)] rounded transition" />
+          <span>Запомнить меня</span>
+        </label>
+        <a href="#" class="text-[var(--brand-primary)] font-medium hover:underline">Забыли пароль?</a>
+      </div>
+
+      <!-- Кнопка входа -->
+      <button type="submit" class="w-full py-3 bg-[var(--text-main)] hover:bg-black text-white text-base font-semibold rounded-lg transition cursor-pointer touch-manipulation">Войти</button>
+
+      <!-- Регистрация -->
+      <p class="text-center text-sm text-secondary mt-6">
+        Нет аккаунта?
+        <a href="{% url 'register' %}" class="text-[var(--brand-primary)] font-medium hover:underline">Регистрация</a>
+      </p>
+    </form>
   </main>
 
-  <!-- Футер -->
-  <footer class="bg-white border-t border-[var(--bg-secondary)] py-6 text-center text-sm text-[var(--text-secondary)]">
-    © 2025 EduPath. <a href="{% url 'about' %}" class="hover:underline">О нас</a> •
-    <a href="{% url 'contacts' %}" class="hover:underline">Контакты</a> •
-    <a href="{% url 'terms' %}" class="hover:underline">Условия</a>
-  </footer>
+  <!-- Скрипты -->
+  <script>
+    function togglePassword(inputId, iconId) {
+      const input = document.getElementById(inputId);
+      const icon = document.getElementById(iconId);
+      const isHidden = input.type === 'password';
+      input.type = isHidden ? 'text' : 'password';
 
+      icon.innerHTML = isHidden
+        ? `<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.269-2.943-9.542-7a10.057 10.057 0 011.846-3.019m3.41-2.44A9.956 9.956 0 0112 5c4.477 0 8.268 2.943 9.542 7a10.053 10.053 0 01-4.109 5.103M15 12a3 3 0 11-6 0 3 3 0 016 0z" />\n           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 3l18 18" />`
+        : `<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />\n           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5s8.268 2.943 9.542 7c-1.274 4.057-5.065 7-9.542 7s-8.268-2.943-9.542-7z" />`;
+    }
+  </script>
 </body>
 </html>

--- a/frontend/templates/Register.html
+++ b/frontend/templates/Register.html
@@ -1,12 +1,14 @@
 {% load static %}
 <!DOCTYPE html>
-<html lang="en" class="scroll-smooth">
+<html lang="ru" class="scroll-smooth">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>EduPath Register</title>
+  <title>EduPath — Регистрация</title>
+
   <script src="https://cdn.tailwindcss.com"></script>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap" rel="stylesheet" />
+
   <style>
     :root {
       --brand-primary: #6C4DFF;
@@ -16,45 +18,109 @@
       --text-secondary: rgba(60, 60, 67, 0.6);
       --border-color: #D1D1D6;
     }
+
     body {
-      font-family: 'Inter', sans-serif;
+      font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
       background-color: var(--bg-main);
       color: var(--text-main);
     }
+
+    .text-secondary {
+      color: var(--text-secondary);
+    }
+
+    input:focus {
+      border-color: var(--brand-primary);
+      box-shadow: 0 0 0 2px var(--brand-primary);
+      outline: none;
+    }
+
+    input, button {
+      transition: all 0.2s ease-in-out;
+      appearance: none;
+      -webkit-appearance: none;
+    }
   </style>
 </head>
-<body class="flex flex-col min-h-screen">
 
-  <main class="flex-1 flex items-center justify-center px-4">
-    <div class="w-full max-w-md bg-white rounded-2xl shadow-xl p-8 space-y-6 border border-[var(--border-color)]">
-      <h2 class="text-2xl font-bold text-center">Регистрация</h2>
+<body class="flex items-center justify-center min-h-screen px-4 relative">
+  <!-- Логотип -->
+  <header class="absolute top-4 left-4 sm:top-6 sm:left-6">
+    <img src="{% static 'Icons/Logo.png' %}" alt="EduPath" class="h-9 sm:h-10 md:h-12" />
+  </header>
 
-      {% if error %}
-        <div class="text-red-600 text-sm text-center">{{ error }}</div>
-      {% endif %}
-
-      <form method="post" action="{% url 'register' %}" class="space-y-4">
-        {% csrf_token %}
-        <input type="text" name="username" required placeholder="Имя пользователя"
-               class="w-full border border-[var(--border-color)] px-4 py-2 rounded-xl focus:outline-none focus:ring-2 focus:ring-[var(--brand-primary)]" />
-        <input type="email" name="email" required placeholder="Email"
-               class="w-full border border-[var(--border-color)] px-4 py-2 rounded-xl focus:outline-none focus:ring-2 focus:ring-[var(--brand-primary)]" />
-        <input type="password" name="password1" required placeholder="Пароль"
-               class="w-full border border-[var(--border-color)] px-4 py-2 rounded-xl focus:outline-none focus:ring-2 focus:ring-[var(--brand-primary)]" />
-        <input type="password" name="password2" required placeholder="Повторите пароль"
-               class="w-full border border-[var(--border-color)] px-4 py-2 rounded-xl focus:outline-none focus:ring-2 focus:ring-[var(--brand-primary)]" />
-        <button type="submit"
-                class="w-full bg-[var(--brand-primary)] hover:bg-indigo-600 text-white px-4 py-2 rounded-xl text-sm font-semibold transition">
-          Зарегистрироваться
-        </button>
-      </form>
-
-      <p class="text-center text-sm text-[var(--text-secondary)]">
-        Уже есть аккаунт?
-        <a href="{% url 'login' %}" class="text-[var(--brand-primary)] hover:underline">Войти</a>
-      </p>
+  <!-- Основной блок -->
+  <main class="w-full max-w-md bg-white rounded-2xl shadow-xl overflow-hidden p-6 sm:p-8 md:p-10 border border-[var(--border-color)]">
+    <div class="mb-8 text-center">
+      <h1 class="text-2xl sm:text-3xl font-semibold mb-1 tracking-tight">Добро пожаловать!</h1>
+      <h2 class="text-base sm:text-lg font-medium mb-2 tracking-tight">Создайте аккаунт</h2>
+      <p class="text-sm text-secondary">Присоединяйтесь и начните путь к знаниям</p>
     </div>
+
+    {% if error %}
+      <div class="text-red-600 text-center text-sm mb-2">{{ error }}</div>
+    {% endif %}
+
+    <!-- Форма -->
+    <form method="post" action="{% url 'register' %}" class="space-y-5 sm:space-y-6">
+      {% csrf_token %}
+      <div>
+        <label for="username" class="block mb-1 text-sm font-medium">Имя пользователя</label>
+        <input id="username" name="username" type="text" placeholder="Введите имя" required class="w-full px-4 py-3 text-sm rounded-lg border border-[var(--border-color)] bg-white transition" />
+      </div>
+
+      <div>
+        <label for="email" class="block mb-1 text-sm font-medium">Электронная почта</label>
+        <input id="email" name="email" type="email" placeholder="Введите email" required class="w-full px-4 py-3 text-sm rounded-lg border border-[var(--border-color)] bg-white transition" />
+      </div>
+
+      <div>
+        <label for="password" class="block mb-1 text-sm font-medium">Пароль</label>
+        <div class="relative">
+          <input id="password" name="password1" type="password" placeholder="Введите пароль" required class="w-full px-4 py-3 text-sm rounded-lg border border-[var(--border-color)] bg-white pr-12 transition" />
+          <button type="button" onclick="togglePassword('password', 'eyeIcon')" class="absolute top-1/2 right-3 -translate-y-1/2" aria-label="Показать пароль">
+            <svg id="eyeIcon" xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 text-gray-500 hover:text-black transition" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5s8.268 2.943 9.542 7c-1.274 4.057-5.065 7-9.542 7s-8.268-2.943-9.542-7z" />
+            </svg>
+          </button>
+        </div>
+      </div>
+
+      <div>
+        <label for="confirmPassword" class="block mb-1 text-sm font-medium">Подтвердите пароль</label>
+        <div class="relative">
+          <input id="confirmPassword" name="password2" type="password" placeholder="Повторите пароль" required class="w-full px-4 py-3 text-sm rounded-lg border border-[var(--border-color)] bg-white pr-12 transition" />
+          <button type="button" onclick="togglePassword('confirmPassword', 'eyeIconConfirm')" class="absolute top-1/2 right-3 -translate-y-1/2" aria-label="Показать пароль">
+            <svg id="eyeIconConfirm" xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 text-gray-500 hover:text-black transition" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5s8.268 2.943 9.542 7c-1.274 4.057-5.065 7-9.542 7s-8.268-2.943-9.542-7z" />
+            </svg>
+          </button>
+        </div>
+      </div>
+
+      <button type="submit" class="w-full py-3 bg-[var(--text-main)] hover:bg-black text-white text-base font-semibold rounded-lg transition">Зарегистрироваться</button>
+
+      <p class="text-center text-sm text-secondary mt-6">
+        Уже есть аккаунт?
+        <a href="{% url 'login' %}" class="text-[var(--brand-primary)] font-medium hover:underline">Войти</a>
+      </p>
+    </form>
   </main>
 
+  <!-- Скрипты -->
+  <script>
+    function togglePassword(inputId, iconId) {
+      const input = document.getElementById(inputId);
+      const icon = document.getElementById(iconId);
+      const isHidden = input.type === 'password';
+      input.type = isHidden ? 'text' : 'password';
+
+      icon.innerHTML = isHidden
+        ? `<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.269-2.943-9.542-7a10.057 10.057 0 011.846-3.019m3.41-2.44A9.956 9.956 0 0112 5c4.477 0 8.268 2.943 9.542 7a10.053 10.053 0 01-4.109 5.103M15 12a3 3 0 11-6 0 3 3 0 016 0z" />\n           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 3l18 18" />`
+        : `<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />\n           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5s8.268 2.943 9.542 7c-1.274 4.057-5.065 7-9.542 7s-8.268-2.943-9.542-7z" />`;
+    }
+  </script>
 </body>
 </html>

--- a/frontend/templates/select_role.html
+++ b/frontend/templates/select_role.html
@@ -1,0 +1,82 @@
+{% load static %}
+<!DOCTYPE html>
+<html lang="ru" class="scroll-smooth">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="apple-mobile-web-app-capable" content="yes" />
+  <meta name="theme-color" content="#F9F9FB" />
+  <title>EduPath — Выбор роли</title>
+
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap" rel="stylesheet" />
+
+  <style>
+    :root {
+      --brand-primary: #6C4DFF;
+      --bg-main: #F9F9FB;
+      --bg-secondary: #EDEDED;
+      --text-main: #1C1C1E;
+      --text-secondary: rgba(60, 60, 67, 0.6);
+      --border-color: #D1D1D6;
+    }
+
+    body {
+      font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+      background-color: var(--bg-main);
+      color: var(--text-main);
+    }
+
+    .text-secondary {
+      color: var(--text-secondary);
+    }
+
+    button {
+      transition: all 0.2s ease-in-out;
+    }
+  </style>
+</head>
+
+<body class="flex items-center justify-center min-h-screen px-4 sm:px-6 lg:px-8 relative">
+  <!-- Логотип -->
+  <header class="absolute top-4 left-4 sm:top-6 sm:left-6">
+    <img src="{% static 'Icons/Logo.png' %}" alt="EduPath" class="h-9 sm:h-10 md:h-12" />
+  </header>
+
+  <!-- Основной блок -->
+  <main class="w-full max-w-md bg-white rounded-2xl shadow-xl overflow-hidden p-6 sm:p-8 md:p-10 border border-[var(--border-color)]">
+    <div class="mb-8 text-center">
+      <h1 class="text-2xl sm:text-3xl font-semibold mb-1 tracking-tight">Выберите свою роль</h1>
+      <h2 class="text-base sm:text-lg font-medium mb-2 tracking-tight">Вы преподаватель или ученик?</h2>
+      <p class="text-xs sm:text-sm text-secondary">Укажите роль, чтобы продолжить</p>
+    </div>
+
+    <div class="space-y-5 sm:space-y-6">
+      <!-- Роль: Преподаватель -->
+      <div class="border border-[var(--border-color)] rounded-2xl p-5 sm:p-6 transition hover:shadow-md hover:border-[var(--brand-primary)] bg-white">
+        <h3 class="text-base sm:text-lg font-semibold mb-2">👨‍🏫 Преподаватель</h3>
+        <p class="text-sm text-secondary mb-4">Управляйте занятиями, создавайте задания и помогайте ученикам.</p>
+        <button onclick="selectRole('teacher')" class="w-full py-3 bg-[var(--text-main)] hover:bg-black text-white text-base font-semibold rounded-lg transition">
+          Выбрать преподавателя
+        </button>
+      </div>
+
+      <!-- Роль: Ученик -->
+      <div class="border border-[var(--border-color)] rounded-2xl p-5 sm:p-6 transition hover:shadow-md hover:border-[var(--brand-primary)] bg-white">
+        <h3 class="text-base sm:text-lg font-semibold mb-2">🎓 Ученик</h3>
+        <p class="text-sm text-secondary mb-4">Присоединяйтесь к занятиям, выполняйте задания и следите за прогрессом.</p>
+        <button onclick="selectRole('student')" class="w-full py-3 bg-[var(--text-main)] hover:bg-black text-white text-base font-semibold rounded-lg transition">
+          Выбрать ученика
+        </button>
+      </div>
+    </div>
+  </main>
+
+  <script>
+    function selectRole(role) {
+      alert(`Вы выбрали роль: ${role === 'teacher' ? 'Преподаватель' : 'Ученик'}`);
+      // Здесь может быть перенаправление на страницы регистрации роли
+    }
+  </script>
+</body>
+</html>

--- a/frontend/urls.py
+++ b/frontend/urls.py
@@ -6,6 +6,7 @@ urlpatterns = [
     path('', views.main_menu, name='main_menu'),
     path('login/', views.login_view, name='login'),
     path('register/', views.register, name='register'),
+    path('select-role/', views.select_role, name='select_role'),
     path('course/', views.course_view, name='course_view'),
 
     # Футер-страницы

--- a/frontend/views.py
+++ b/frontend/views.py
@@ -19,7 +19,7 @@ def login_view(request):
         user = authenticate(request, username=username, password=password)
         if user is not None:
             login(request, user)
-            return redirect('main_menu')
+            return redirect('select_role')
         else:
             return render(request, 'Login.html', {'error': 'Неверный логин или пароль'})
 
@@ -42,7 +42,7 @@ def register(request):
 
         user = User.objects.create_user(username=username, email=email, password=password1)
         login(request, user)
-        return redirect('main_menu')
+        return redirect('select_role')
 
     return render(request, 'Register.html')
 
@@ -61,3 +61,8 @@ def contact_view(request):
 
 def terms_view(request):
     return render(request, 'terms.html')
+
+
+# Страница выбора роли
+def select_role(request):
+    return render(request, 'select_role.html')


### PR DESCRIPTION
## Summary
- update login/register templates to new design
- redirect auth flow to a role selection page
- add new select-role template and route

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_684f0ec389308325a5e67b4666af39c3